### PR TITLE
Implemented helm charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,12 @@ nfs-server:
 	
 .PHONY: deploy
 deploy:
-	kubectl apply -f deploy
+	helm install csi-driver-nfs-export ./charts --set plugin.imagePullPolicy=Always
 	kubectl rollout status deploy,ds --timeout=90s
 	kubectl get pod -l nfs-export.csi.k8s.io/server
 
 undeploy: 
-	kubectl delete -f deploy/ || true
+	helm uninstall csi-driver-nfs-export
 	kubectl wait po -l nfs-export.csi.k8s.io/server --for=delete --timeout=90s
 	kubectl get pod -l nfs-export.csi.k8s.io/server
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,2 +1,2 @@
 Alex Zheng <alex.zheng@daocloud.io>
-Wang Wei
+Wang Wei <wangw77@spdb.com.cn>

--- a/charts/.helmignore
+++ b/charts/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: v0.0.1
+description: CSI NFS Export Driver for Kubernetes
+name: csi-driver-nfs-export
+version: v0.0.1

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,0 +1,1 @@
+CSI NFT Export Driver

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Expand the name of the chart.*/}}
+{{- define "nfs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* labels for helm resources */}}
+{{- define "nfs.labels" -}}
+labels:
+  app.kubernetes.io/instance: "{{ .Release.Name }}"
+  app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+  app.kubernetes.io/name: "{{ template "nfs.name" . }}"
+  app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
+  helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  {{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 2 -}}
+  {{- end }}
+{{- end -}}

--- a/charts/templates/controller.yaml
+++ b/charts/templates/controller.yaml
@@ -1,0 +1,113 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: csi-nfs-export-controller
+  labels:
+    nfs-export.csi.k8s.io/server: controller
+spec:
+  replicas: {{ .Values.controllerReplicas }}
+  selector:
+    matchLabels:
+      nfs-export.csi.k8s.io/server: controller
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        nfs-export.csi.k8s.io/server: controller
+    spec:
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true  # controller also needs to mount nfs to create dir
+      dnsPolicy: Default  # available values: {{ .Release.Namespace }}, ClusterFirstWithHostNet, ClusterFirst
+      serviceAccountName: csi-nfs-export-controller-sa
+      nodeSelector:
+        kubernetes.io/os: linux  # add "kubernetes.io/role: master" to run controller on master node
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/controlplane"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+      containers:
+        - name: provisioner
+          image: {{ .Values.provisioner.image }}
+          imagePullPolicy: {{ .Values.provisioner.imagePullPolicy }}
+          args:
+            - "-v=2"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--leader-election-namespace=$(NAMESPACE)"
+            - "--extra-create-metadata=true"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          resources: {}
+        - name: liveness-probe
+          image: {{ .Values.livenessProbe.image }}
+          imagePullPolicy: {{ .Values.livenessProbe.imagePullPolicy }}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=29652
+            - --v=2
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources: {}
+        - name: plugin
+          image: {{ .Values.plugin.image }}
+          imagePullPolicy: {{ .Values.plugin.imagePullPolicy }}
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          args:
+            - "-v=5"
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+          env:   
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+          ports:
+            - containerPort: 29652
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 30
+          volumeMounts:
+            - name: pods-mount-dir
+              mountPath: {{ .Values.kubeletRoot }}/pods
+              mountPropagation: "Bidirectional"
+            - mountPath: /csi
+              name: socket-dir
+          resources: {}
+      volumes:
+        - name: pods-mount-dir
+          hostPath:
+            path: {{ .Values.kubeletRoot }}/pods
+            type: Directory
+        - name: socket-dir
+          emptyDir: {}

--- a/charts/templates/csidriver.yaml
+++ b/charts/templates/csidriver.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: nfs-export.csi.k8s.io
+spec:
+  attachRequired: false
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral
+  fsGroupPolicy: File
+  podInfoOnMount: true

--- a/charts/templates/node.yaml
+++ b/charts/templates/node.yaml
@@ -1,0 +1,132 @@
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-nfs-export-node
+  labels:
+    nfs-export.csi.k8s.io/server: node
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      nfs-export.csi.k8s.io/server: node
+  template:
+    metadata:
+      labels:
+        nfs-export.csi.k8s.io/server: node
+    spec:
+      hostNetwork: true  # original nfs connection would be broken without hostNetwork setting
+      dnsPolicy: Default  # available values: Default, ClusterFirstWithHostNet, ClusterFirst
+      serviceAccountName: csi-nfs-export-node-sa
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: "Exists"
+      containers:
+        - name: liveness-probe
+          image: {{ .Values.livenessProbe.image }}
+          imagePullPolicy: {{ .Values.livenessProbe.imagePullPolicy }}
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=29653
+            - --v=2
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources: {}
+        - name: node-driver-registrar
+          image: {{ .Values.nodeDriverRegistrar.image }}
+          imagePullPolicy: {{ .Values.nodeDriverRegistrar.imagePullPolicy }}
+          args:
+            - --v=2
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+          livenessProbe:
+            exec:
+              command:
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+                - --mode=kubelet-registration-probe
+            initialDelaySeconds: 30
+            timeoutSeconds: 15
+          env:
+            - name: DRIVER_REG_SOCK_PATH
+              value: {{ .Values.kubeletRoot }}/plugins/csi-nfsplugin/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+            - mountPath: {{ .Values.kubeletRoot }}/pods
+              name: pods-mount-dir
+            # - mountPath: /pods 
+            #   name: pods-mount-dir
+            - name: local-volumes
+              mountPath: /volumes
+          resources: {}
+        - name: nfs-export
+          image: {{ .Values.plugin.image }}
+          imagePullPolicy: {{ .Values.plugin.imagePullPolicy }}
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          args:
+            - "-v=5"
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+          ports:
+            - containerPort: 29653
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 30
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: {{ .Values.kubeletRoot }}/pods
+              mountPropagation: Bidirectional
+            - name: local-volumes
+              mountPath: /volumes
+              mountPropagation: Bidirectional
+          resources: {}
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: {{ .Values.kubeletRoot }}/plugins/csi-nfsplugin
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: {{ .Values.kubeletRoot }}/pods
+            type: Directory
+        - hostPath:
+            path: {{ .Values.kubeletRoot }}/plugins_registry
+            type: Directory
+          name: registration-dir
+        - name: local-volumes
+          hostPath:
+            path: /var/lib/csi-nfs-export/volumes/
+            type: DirectoryOrCreate

--- a/charts/templates/rbac.yaml
+++ b/charts/templates/rbac.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-nfs-export-controller-sa
+  namespace: {{ .Release.Namespace }}
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nfs-export-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nfs-export-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-nfs-export-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: csi-nfs-export-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-nfs-export-node-sa
+  namespace: {{ .Release.Namespace }}
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nfs-export-node-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-nfs-export-node-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-nfs-export-node-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: csi-nfs-export-node-role
+  apiGroup: rbac.authorization.k8s.io
+
+
+

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,0 +1,21 @@
+kubeletRoot: /var/snap/microk8s/common/var/lib/kubelet/ # for microk8s
+
+controllerReplicas: 1
+
+provisioner:
+  image: k8s.m.daocloud.io/sig-storage/csi-provisioner:v3.2.0
+  imagePullPolicy: IfNotPresent
+
+nodeDriverRegistrar:
+  image: k8s.m.daocloud.io/sig-storage/csi-node-driver-registrar:v2.5.1
+  imagePullPolicy: IfNotPresent
+
+livenessProbe:
+  image: k8s.m.daocloud.io/sig-storage/livenessprobe:v2.7.0
+  imagePullPolicy: IfNotPresent
+
+plugin:
+  image: daocloud.io/piraeus/csi-nfs-export-plugin:latest
+  imagePullPolicy: IfNotPresent # for devops, set it "Always"
+
+


### PR DESCRIPTION
This PR implements helm charts which can customize:
1. namespace (including rbac's)
2. kubelet root
3. controller replicas
4. images
5. pull policy 

Makefile is also adjusted to use helm for `make deply/undeploy'